### PR TITLE
Fix: Add multi-platform support for preview image

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -26,5 +26,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: rafaeljusto/autoenv:v${{ steps.find_tag.outputs.tag }}


### PR DESCRIPTION
This should fix the problem when k8s is running in an arm64 environment.